### PR TITLE
Db go on

### DIFF
--- a/src/common/components/MovieHeader/index.js
+++ b/src/common/components/MovieHeader/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Overlay from "react-image-overlay";
 import { Backdrop } from "./styled";
 import rateIcon from "../Tiles/rateIcon.svg";
 import { Wrapper } from "./styled";

--- a/src/common/components/Tiles/MiddleTile/index.js
+++ b/src/common/components/Tiles/MiddleTile/index.js
@@ -35,30 +35,31 @@ export const MiddleTile = ({
 }) => {
     return (
         <TileContainer onClick={onClick}>
-            <div> <Poster src={`${URLimage}${poster}`} alt="" /></div>
             <Content>
+                <div> <Poster src={`${URLimage}${poster}`} alt="" /></div>
 
                 <div>
-                <Title>{title}</Title>
-                <Year>{year}</Year>
-                <Wrapper>
-                    {genres &&
-                        genres.map((genre) => {
-                            return AllGenresData.genres.map((item) =>
-                                item.id === genre ? (
-                                    <Genres key={nanoid()}>{item.name}</Genres>
-                                ) : null
-                            )
-                        })}
-                </Wrapper>
+                    <Title>{title}</Title>
+                    <Year>{year}</Year>
+                    <Wrapper>
+                        {genres &&
+                            genres.map((genre) => {
+                                return AllGenresData.genres.map((item) =>
+                                    item.id === genre ? (
+                                        <Genres key={nanoid()}>{item.name}</Genres>
+                                    ) : null
+                                )
+                            })}
+                    </Wrapper>
                 </div>
-                <Wrapper>
-                    <Icon src={rateIcon} alt="" />
-                    <Rate>{rate}</Rate>
-                    <Score>{score}</Score>
-                    <Score>{votes} votes</Score>
-                </Wrapper>
             </Content>
+            <Wrapper rates>
+                <Icon src={rateIcon} alt="" />
+                <Rate>{rate}</Rate>
+                <Score>{score}</Score>
+                <Score>{votes} votes</Score>
+            </Wrapper>
+
         </TileContainer>
     )
 }

--- a/src/common/components/Tiles/MiddleTile/index.js
+++ b/src/common/components/Tiles/MiddleTile/index.js
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react'
+import {
+    Content,
+    Poster,
+    Title,
+    Year,
+    TileContainer,
+    Wrapper,
+    InfoDetails,
+    Overview,
+    Genres,
+    Rate,
+    Score,
+    Icon,
+    Info,
+} from './styled'
+import rateIcon from '../rateIcon.svg'
+import AllGenresData from '../../../assets/generalData/genreData.json'
+import { URLimage } from '../../../assets/generalData/fetchedData'
+import { nanoid } from 'nanoid'
+
+export const MiddleTile = ({
+    onClick,
+    title,
+    poster,
+    year,
+    country,
+    production,
+    date,
+    genres,
+    rate,
+    score,
+    votes,
+    overview,
+}) => {
+    return (
+        <TileContainer onClick={onClick}>
+            <div> <Poster src={`${URLimage}${poster}`} alt="" /></div>
+            <Content>
+
+                <div>
+                <Title>{title}</Title>
+                <Year>{year}</Year>
+                <Wrapper>
+                    {genres &&
+                        genres.map((genre) => {
+                            return AllGenresData.genres.map((item) =>
+                                item.id === genre ? (
+                                    <Genres key={nanoid()}>{item.name}</Genres>
+                                ) : null
+                            )
+                        })}
+                </Wrapper>
+                </div>
+                <Wrapper>
+                    <Icon src={rateIcon} alt="" />
+                    <Rate>{rate}</Rate>
+                    <Score>{score}</Score>
+                    <Score>{votes} votes</Score>
+                </Wrapper>
+            </Content>
+        </TileContainer>
+    )
+}

--- a/src/common/components/Tiles/MiddleTile/styled.js
+++ b/src/common/components/Tiles/MiddleTile/styled.js
@@ -1,0 +1,124 @@
+import styled, { css } from 'styled-components'
+
+export const TileContainer = styled.div`
+    background: ${({ theme }) => theme.color.white};
+    width: 324px;
+    min-height:650px;
+    padding: 16px;
+    box-shadow: 0px 4px 12px rgba(186, 199, 213, 0.5);
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    align-items: left;
+    padding-left: 16px;
+    padding-right: 16px;
+
+
+
+    
+    /* @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
+        display: flex;
+        
+        padding: 16px;
+    } */
+`
+
+export const Poster = styled.img`
+    width: 292px;
+    height: auto;
+    display: block;
+    border-radius: 5px;
+    margin-bottom:8px;
+    
+
+    
+    /* @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
+        width: 114px;
+    } */
+`
+
+export const Content = styled.div`
+   
+`
+
+export const Title = styled.header`
+    font-weight: 600;
+    font-size: 36px;
+    display: flex;
+    flex-wrap: wrap;
+    overflow-wrap: break-word;
+    margin:8px 0;
+    
+
+    /* @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
+        font-size: 16px;
+    } */
+`
+
+export const Year = styled.div`
+    font-size: 22px;
+    
+
+    @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
+        font-size: 13px;
+        margin: 0;
+    }
+`
+
+export const Wrapper = styled.ul`
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    padding-left: 0;
+    margin: 0 -8px;
+
+    @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
+    }
+`
+
+export const Genres = styled.li`
+    padding: 8px 16px;
+    background-color: ${({ theme }) => theme.color.mystic};
+    font-size: 14px;
+    margin: 8px;
+    border-radius: 5px;
+
+    @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
+        font-size: 10px;
+        line-height: 1.1;
+    }
+`
+
+export const Icon = styled.img`
+    width: 24px;
+    height: 22.87px;
+    color: ${({ theme }) => theme.color.candlelight};
+    margin: 27.09px 0 -8px 8px;
+`
+
+export const Rate = styled.li`
+    width: 32px;
+    height: 29px;
+    font-size: 22px;
+    font-weight: 500;
+    line-height: 1.3;
+    align-items: center;
+    margin: 27.09px 8px;
+
+    @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
+        font-size: 13px;
+    }
+`
+
+export const Score = styled.li`
+    font-size: 14px;
+    line-height: 1.2;
+    margin: 33px 8px;
+
+    @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
+        font-size: 13px;
+    }
+`
+
+

--- a/src/common/components/Tiles/MiddleTile/styled.js
+++ b/src/common/components/Tiles/MiddleTile/styled.js
@@ -4,7 +4,6 @@ export const TileContainer = styled.div`
     background: ${({ theme }) => theme.color.white};
     width: 324px;
     min-height:650px;
-    padding: 16px;
     box-shadow: 0px 4px 12px rgba(186, 199, 213, 0.5);
     display: flex;
     flex-direction: column;
@@ -12,58 +11,50 @@ export const TileContainer = styled.div`
     align-items: left;
     padding-left: 16px;
     padding-right: 16px;
-
-
-
-    
-    /* @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
-        display: flex;
-        
-        padding: 16px;
-    } */
-`
+    justify-content: space-between;   
+`;
 
 export const Poster = styled.img`
     width: 292px;
     height: auto;
     display: block;
     border-radius: 5px;
+    margin-top:16px;
     margin-bottom:8px;
-    
-
-    
-    /* @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
-        width: 114px;
-    } */
-`
+`;
 
 export const Content = styled.div`
-   
-`
+    display:flex;
+    flex-direction: column;
+    align-content: space-between;  
+`;
 
 export const Title = styled.header`
-    font-weight: 600;
-    font-size: 36px;
+    font-weight: 500;
+    font-size: 22px;
     display: flex;
     flex-wrap: wrap;
     overflow-wrap: break-word;
-    margin:8px 0;
+    margin:4px 0;
+    line-height: 1.3;
     
-
     /* @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
         font-size: 16px;
     } */
-`
+`;
 
-export const Year = styled.div`
-    font-size: 22px;
+export const Year = styled.p`
+    font-weight: 400px;
+    font-size: 16px;
+    line-height: 1.5;
+    margin:4px 0;
+    color: ${({ theme }) => theme.color.waterloo};
     
-
     @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
         font-size: 13px;
         margin: 0;
     }
-`
+`;
 
 export const Wrapper = styled.ul`
     list-style: none;
@@ -71,54 +62,55 @@ export const Wrapper = styled.ul`
     flex-wrap: wrap;
     justify-content: flex-start;
     padding-left: 0;
-    margin: 0 -8px;
+    margin: 4px -8px 0px -4px;
+ 
+    ${({ rates }) => rates && css`
+        gap:8px;
+        margin: 8px 0 16px 0;
+        justify-content: flex-start;
+    `}
 
     @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
     }
-`
+`;
 
 export const Genres = styled.li`
     padding: 8px 16px;
     background-color: ${({ theme }) => theme.color.mystic};
     font-size: 14px;
-    margin: 8px;
+    margin: 4px;
     border-radius: 5px;
 
     @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
         font-size: 10px;
         line-height: 1.1;
     }
-`
+`;
 
 export const Icon = styled.img`
     width: 24px;
-    height: 22.87px;
-    color: ${({ theme }) => theme.color.candlelight};
-    margin: 27.09px 0 -8px 8px;
-`
+    height: 20.87px;
+    color: ${({ theme }) => theme.color.candlelight};   
+`;
 
 export const Rate = styled.li`
-    width: 32px;
-    height: 29px;
-    font-size: 22px;
-    font-weight: 500;
+    font-size: 16px;
+    font-weight: 600;
     line-height: 1.3;
+    text-align: center;
     align-items: center;
-    margin: 27.09px 8px;
 
     @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
         font-size: 13px;
     }
-`
+`;
 
 export const Score = styled.li`
-    font-size: 14px;
+    font-size: 16px;
+    font-weight: 400px;
     line-height: 1.2;
-    margin: 33px 8px;
 
     @media (max-width: ${({ theme }) => theme.breakpoints.mobileNormal}) {
         font-size: 13px;
     }
-`
-
-
+`;

--- a/src/core/App/App.js
+++ b/src/core/App/App.js
@@ -3,8 +3,8 @@
 import Header from '../../common//components/Header'
 import Main from '../../common/Main/index'
 import { Container } from '../../common/components/Container'
-import MoviePage from '../../features/MoviePage'
-import MovieList from '../../features/MovieList'
+import MoviePage from '../../features/movies/MoviePage'
+import MovieList from '../../features/movies/MovieList'
 import { MovieHeader } from "../../common/components/MovieHeader"
 
 function App() {

--- a/src/core/App/App.js
+++ b/src/core/App/App.js
@@ -12,10 +12,10 @@ function App() {
         <div>
             <Header />
             {/* <Loader /> */}
-            <MovieHeader />
+            {/* <MovieHeader /> */}
             <Container>
-                {/* <MovieList /> */}
-                <MoviePage />
+                <MovieList />
+                {/* <MoviePage /> */}
             </Container>
             {/* <Main /> */}
         </div>

--- a/src/features/movies/MovieList/index.js
+++ b/src/features/movies/MovieList/index.js
@@ -3,6 +3,7 @@ import { URLpopularMovies } from '../../../common/assets/generalData/fetchedData
 import { Tile } from '../../../common/components/Tiles/BigTile'
 import { Loader } from '../../../common/components/Loader'
 import { nanoid } from 'nanoid'
+import { MiddleTile } from "../../../common/components/Tiles/MiddleTile"
 
 const MovieList = () => {
     const [isLoading, setIsLoading] = useState(true)
@@ -18,14 +19,10 @@ const MovieList = () => {
         console.log(id)
         setShowAll(!showAll)
         console.log(showAll)
-
-        // if (index === tileIndex) {
-        //     console.log('from if:', tileIndex)
-        // }
     }
 
     useEffect(() => {
-        ;(async () => {
+        ; (async () => {
             const response = await fetch(URLpopularMovies)
             setMovies(await response.json())
             // console.log('movies:', movies)
@@ -42,14 +39,15 @@ const MovieList = () => {
             ) : showAll ? (
                 movies.results.map((movie) => (
                     <>
-                        <Tile
+                        <MiddleTile
                             key={nanoid()}
                             onClick={() => handleOnClick(movie.id)}
                             showAll={showAll}
                             title={movie.title}
                             poster={movie.poster_path}
-                            date={movie.release_date.slice(0, 4)}
+                            year={movie.release_date.slice(0, 4)}
                             rate={movie.vote_average}
+                            score="/10"
                             votes={movie.vote_count}
                             genres={movie.genre_ids}
                         />
@@ -59,8 +57,8 @@ const MovieList = () => {
                 movies.results.map((movie) => {
                     if (movie.id === tileIndex) {
                         return (
-                            <Tile
-                                little
+                            <MiddleTile
+
                                 key={nanoid()}
                                 onClick={() => handleOnClick(movie.id)}
                                 title={movie.title}


### PR DESCRIPTION
Here're medium size tiles created. For that moment they're for desktop only. @mediaquery  needs to be fixed.
It'd be fine to find better position of the text on the bottom of the tile in relation to the star-icon. I have no idea to improve it.
Medium size tile has its own MediaTile folder yet. Later we can gather all similar tiles in one with props as it is possible.

Gaps between elements are like it is given in figma project.
Pictures and other datas are loaded from Api.
Next we need to place the text"Popular movies" and should cover all this page under the general header that's made by @miloszzaj , so this way if you scroll the page the header will stay visible.
I'll be grateful for any suggestions as for that piece of work :)
